### PR TITLE
Pass global options to standard

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -51,7 +51,8 @@ var StandardValidationFilter = function (inputNode, options = {}) {
     format: options.format ? options.format : undefined,
     throwOnError: options.throwOnError ? options.throwOnError : false,
     logOutput: options.logOutput ? options.logOutput : false,
-    fix: options.fix ? options.fix : false
+    fix: options.fix ? options.fix : false,
+    globals: options.globals || options.global
   }
   this.ignore = options.ignore ? options.ignore : function () {
     return false


### PR DESCRIPTION
Fixes #1

Adds the `global` or `globals` option to the `internalOptions` object, allowing someone to pass a globals array to the standard linter.  This will not prevent the `package.json` of the main file from adding its own `globals` options on top of this option.